### PR TITLE
Add module: @mlld/fs

### DIFF
--- a/modules/mlld-lang/registry.json
+++ b/modules/mlld-lang/registry.json
@@ -1,0 +1,29 @@
+{
+  "author": "mlld-lang",
+  "modules": {
+    "@mlld/fs": {
+      "name": "@mlld/fs",
+      "description": "Filesystem operations for directory contents as XML or Markdown",
+      "author": {
+        "name": "Module Author",
+        "github": "mlld-lang"
+      },
+      "source": {
+        "type": "github",
+        "repo": "mlld-lang/modules",
+        "hash": "4b10ee4e792adba7e5bf43ffff0808a0824b1a75",
+        "url": "https://raw.githubusercontent.com/mlld-lang/modules/4b10ee4e792adba7e5bf43ffff0808a0824b1a75/fs/fs.mld"
+      },
+      "dependencies": {},
+      "keywords": [
+        "filesystem",
+        "xml",
+        "markdown",
+        "tree",
+        "directory"
+      ],
+      "mlldVersion": ">=0.5.0",
+      "publishedAt": "2025-05-31T07:01:45.033Z"
+    }
+  }
+}


### PR DESCRIPTION
## New Module: @mlld/fs

### Description
Filesystem operations for directory contents as XML or Markdown

### Author
- Name: Module Author
- GitHub: @mlld-lang

### Source
- Gist: https://gist.github.com/undefined/undefined
- Raw URL: https://raw.githubusercontent.com/mlld-lang/modules/4b10ee4e792adba7e5bf43ffff0808a0824b1a75/fs/fs.mld

### Keywords
`filesystem`, `xml`, `markdown`, `tree`, `directory`

---
*This PR was created automatically via `mlld registry publish`*