### PR TITLE
Add @mlld-dev/string-utils

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -50,5 +50,28 @@
       "mlldVersion": ">=0.5.0",
       "publishedAt": "2025-05-30T00:00:00Z"
     }
+  },
+  "@mlld-dev/string-utils": {
+    "name": "string-utils",
+    "description": "Useful string manipulation utilities for mlld",
+    "author": {
+      "name": "mlld-dev",
+      "github": "mlld-dev"
+    },
+    "source": {
+      "type": "gist",
+      "url": "https://gist.githubusercontent.com/mlld-dev/fc24e627be5b04f0c73d37a5d53b5abb/raw/f27d6fca5316286e137c1cf4a710d80c2393cd7c/string-utils.mld",
+      "gistId": "fc24e627be5b04f0c73d37a5d53b5abb",
+      "contentHash": "336fb90f84baeb4c68560f84ea23a060fd10fb21ba51feae3b608bade9ad6159"
+    },
+    "publishedAt": "2025-06-08T22:35:09.536Z",
+    "mlldVersion": ">=0.5.0",
+    "keywords": [
+      "strings",
+      "utilities",
+      "text"
+    ],
+    "version": "1.0.0",
+    "license": "MIT"
   }
 }


### PR DESCRIPTION
Adding new module: **@mlld-dev/string-utils**

## Module Information
- **Description**: Useful string manipulation utilities for mlld
- **Version**: 1.0.0
- **Source Type**: gist
- **Source URL**: https://gist.githubusercontent.com/mlld-dev/fc24e627be5b04f0c73d37a5d53b5abb/raw/f27d6fca5316286e137c1cf4a710d80c2393cd7c/string-utils.mld
- **Content Hash**: `336fb90f84baeb4c68560f84ea23a060fd10fb21ba51feae3b608bade9ad6159`



- **Keywords**: strings, utilities, text
- **License**: MIT

## Validation
This PR will be automatically validated by the registry workflow to ensure:
- ✅ Module name matches author
- ✅ Source URL is accessible
- ✅ Content hash matches
- ✅ Valid mlld syntax


