### PR TITLE
Add @mlld-dev/color-utils

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -50,5 +50,32 @@
       "mlldVersion": ">=0.5.0",
       "publishedAt": "2025-05-30T00:00:00Z"
     }
+  },
+  "@mlld-dev/color-utils": {
+    "name": "color-utils",
+    "description": "Terminal color utilities for mlld output",
+    "author": {
+      "name": "mlld-dev",
+      "github": "mlld-dev"
+    },
+    "source": {
+      "type": "github",
+      "url": "https://raw.githubusercontent.com/mlld-dev/test-mlld-modules/2aa852016669c0a411a95966692cca923039879f/color-utils.mld",
+      "contentHash": "656b6c0610fd17d8956a64025fd305a75347813f2bf8dbc9d0cce1b61eda12e1",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mlld-dev/test-mlld-modules",
+        "commit": "2aa852016669c0a411a95966692cca923039879f",
+        "path": "color-utils.mld"
+      }
+    },
+    "publishedAt": "2025-06-08T23:38:25.302Z",
+    "mlldVersion": ">=0.5.0",
+    "keywords": [
+      "color",
+      "terminal",
+      "ansi"
+    ],
+    "version": "1.0.0"
   }
 }


### PR DESCRIPTION
Adding new module: **@mlld-dev/color-utils**

## Module Information
- **Description**: Terminal color utilities for mlld output
- **Version**: 1.0.0
- **Source Type**: github
- **Source URL**: https://raw.githubusercontent.com/mlld-dev/test-mlld-modules/2aa852016669c0a411a95966692cca923039879f/color-utils.mld
- **Content Hash**: `656b6c0610fd17d8956a64025fd305a75347813f2bf8dbc9d0cce1b61eda12e1`
- **Repository**: https://github.com/mlld-dev/test-mlld-modules
- **Commit**: `2aa852016669c0a411a95966692cca923039879f`
- **Path**: `color-utils.mld`
- **Keywords**: color, terminal, ansi
- **License**: Not specified

## Validation
This PR will be automatically validated by the registry workflow to ensure:
- ✅ Module name matches author
- ✅ Source URL is accessible
- ✅ Content hash matches
- ✅ Valid mlld syntax
- ✅ Git commit exists and is immutable

